### PR TITLE
Fix of https://github.com/avast/sms-ticket/issues/19

### DIFF
--- a/mobile/src/main/res/layout/dialog_part_datepicker.xml
+++ b/mobile/src/main/res/layout/dialog_part_datepicker.xml
@@ -19,4 +19,5 @@
 <DatePicker
     android:id="@+id/datepicker"
     style="@style/datepicker"
+    android:datePickerMode="spinner"
     xmlns:android="http://schemas.android.com/apk/res/android" />


### PR DESCRIPTION
On Android 5+ listener onDateChanged in DatePicker is not called unless the datepicker is in spinner mode.
