### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/core/Constants.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/core/Constants.java
@@ -34,4 +34,6 @@ public class Constants {
     public static final int LOADER_CITIES = 2;
     public static final int LOADER_CITY_TICKETS = 3;
     public static final int LOADER_STATISTICS = 4;
+
+    private Constants() {}
 }

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/data/Preferences.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/data/Preferences.java
@@ -41,6 +41,7 @@ public class Preferences {
 
     public static final int VALUE_DEFAULT_SIM = -1;
 
+    private Preferences() {}
 
     public static int getInt(Context c, String key, int defaultValue) {
         return PreferenceManager.getDefaultSharedPreferences(c).getInt(key, defaultValue);

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/framework/SL.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/framework/SL.java
@@ -33,6 +33,8 @@ import eu.inmite.apps.smsjizdenka.framework.interfaces.IGetInstanceInit;
  */
 public class SL {
 
+    private SL() {}
+
     /**
      * Return instance of desired class or object that implement desired interface.
      */

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/framework/about/Constants.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/framework/about/Constants.java
@@ -67,6 +67,7 @@ public class Constants {
         new Library("com.github.kovmarci86.android.secure.preferences.SecureSharedPreferences", "Secure Preferences", "Marcell Kovacs", APACHE, "https://github.com/kovmarci86/android-secure-preferences"),
     };
 
+    private Constants() {}
 
     public static class Library {
         public String name;

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/framework/util/IntentUtils.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/framework/util/IntentUtils.java
@@ -33,6 +33,8 @@ import android.text.TextUtils;
 @SuppressWarnings("UnusedDeclaration")
 public class IntentUtils {
 
+    private IntentUtils() {}
+
     /**
      * Opens e-mail client, e.g. Gmail.
      *

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/framework/util/StreamUtils.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/framework/util/StreamUtils.java
@@ -33,6 +33,8 @@ import eu.inmite.apps.smsjizdenka.framework.DebugLog;
  */
 public class StreamUtils {
 
+    private StreamUtils() {}
+
     public static String streamToString(InputStream is) throws IOException {
         try {
             return streamToString(new InputStreamReader(is, "UTF-8"));

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/framework/util/UIUtils.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/framework/util/UIUtils.java
@@ -26,6 +26,8 @@ import android.util.DisplayMetrics;
  */
 public class UIUtils {
 
+    private UIUtils() {}
+
     public static boolean isHoneycomb() {
         // Can use static final constants like HONEYCOMB, declared in later versions
         // of the OS since they are inlined at compile time. This is guaranteed behavior.

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/util/AnimationUtil.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/util/AnimationUtil.java
@@ -36,6 +36,8 @@ public class AnimationUtil {
 
     public static int NO_ANIMATION = -1;
 
+    private AnimationUtil() {}
+
     public static void addAnimationToView(final View view, final int animation) {
         if (view == null) {
             return;

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/util/FormatUtil.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/util/FormatUtil.java
@@ -36,6 +36,8 @@ import eu.inmite.apps.smsjizdenka.R;
 public class FormatUtil {
 
 
+    private FormatUtil() {}
+
     public static Time timeFrom3339(String s3339) {
         final android.text.format.Time time = new Time();
         if (TextUtils.isEmpty(s3339)) {

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/util/LanguageUtil.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/util/LanguageUtil.java
@@ -28,6 +28,8 @@ public class LanguageUtil {
 
     private static String cachedCountry;
 
+    private LanguageUtil() {}
+
     public static String getSimCountry(Context c) {
         if (cachedCountry != null) {
             return cachedCountry;

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/util/LocaleUtils.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/util/LocaleUtils.java
@@ -44,6 +44,8 @@ public class LocaleUtils {
 
 	/* public static Locale forceLocale = null; */
 
+    private LocaleUtils() {}
+
     /**
      * Set new default currency for price formatting.
      */

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/util/NotificationUtil.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/util/NotificationUtil.java
@@ -49,6 +49,8 @@ public class NotificationUtil {
     public static final int NOTIFICATION_VERIFY = 42;
     public static final int NOTIFICATION_MESSAGE = 43;
 
+    private NotificationUtil() {}
+
     /**
      * Posts notification about new sms ticket.
      *

--- a/wear/src/main/java/eu/inmite/apps/smsjizdenka/core/Constants.java
+++ b/wear/src/main/java/eu/inmite/apps/smsjizdenka/core/Constants.java
@@ -63,4 +63,5 @@ public class Constants {
         CITIES_BACKGROUND_MAP.put(9L, R.drawable.city_ceskebudejovice);
     }
 
+    private Constants() {}
 }

--- a/wear/src/main/java/eu/inmite/apps/smsjizdenka/core/DebugLog.java
+++ b/wear/src/main/java/eu/inmite/apps/smsjizdenka/core/DebugLog.java
@@ -28,6 +28,8 @@ public class DebugLog {
     private static long startTime;
     private static long previousTime;
 
+    private DebugLog() {}
+
     public static void d(Object text) {
         Log.d(DEFAULT_TAG, text.toString());
     }

--- a/wear/src/main/java/eu/inmite/apps/smsjizdenka/util/FormatUtil.java
+++ b/wear/src/main/java/eu/inmite/apps/smsjizdenka/util/FormatUtil.java
@@ -35,6 +35,7 @@ import eu.inmite.apps.smsjizdenka.R;
  */
 public class FormatUtil {
 
+    private FormatUtil() {}
 
     public static Time timeFrom3339(String s3339) {
         final Time time = new Time();

--- a/wear/src/main/java/eu/inmite/apps/smsjizdenka/util/ImageUtil.java
+++ b/wear/src/main/java/eu/inmite/apps/smsjizdenka/util/ImageUtil.java
@@ -28,6 +28,8 @@ import android.graphics.drawable.Drawable;
  */
 public class ImageUtil {
 
+    private ImageUtil() {}
+
     public static Bitmap combineTwoImages(Context context, int backgroundResource, int color) {
 
         Bitmap bmpBackground = null;

--- a/wear/src/main/java/eu/inmite/apps/smsjizdenka/util/LocaleUtils.java
+++ b/wear/src/main/java/eu/inmite/apps/smsjizdenka/util/LocaleUtils.java
@@ -38,6 +38,8 @@ public class LocaleUtils {
      */
     public static boolean sPostFormatCurrency = false;
 
+    private LocaleUtils() {}
+
     /**
      * Format number like 1 123 Kč.
      */


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
This pull request removes technical debt of 510 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava
