### PR TITLE
squid:S1319 - Declarations should use Java collection interfaces such as List rather than specific implementation classes such as LinkedList

### DIFF
--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/data/model/CityManager.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/data/model/CityManager.java
@@ -42,7 +42,7 @@ public class CityManager {
         return (CityManager)((Application)context.getApplicationContext()).getSystemService(CITY_MANAGER_SERVICE);
     }
 
-    public ArrayList<City> resolveCity(Context context, String number, String message) {
+    public List<City> resolveCity(Context context, String number, String message) {
         ArrayList<City> cities = null;
         Cursor c = context.getContentResolver().query(Cities.CONTENT_URI, null, Cities.NUMBER + " = ? OR " + Cities.ADDITIONAL_NUMBER_1 + " = ? OR " + Cities.ADDITIONAL_NUMBER_2 + " = ? OR " + Cities.ADDITIONAL_NUMBER_3 + " = ?", new String[]{number, number, number, number}, null);
 

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/receiver/SmsReceiver.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/receiver/SmsReceiver.java
@@ -18,6 +18,7 @@ package eu.inmite.apps.smsjizdenka.receiver;
 
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.List;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -135,7 +136,7 @@ public class SmsReceiver extends BroadcastReceiver {
 
         DebugLog.i("receiving sms from " + m.getOriginatingAddress() + " with text " + message);
 
-        final ArrayList<City> cities = CityManager.get(c).resolveCity(c, m.getOriginatingAddress(), message);
+        final List<City> cities = CityManager.get(c).resolveCity(c, m.getOriginatingAddress(), message);
         if (cities == null || cities.isEmpty()) {
             DebugLog.w("no city recognized");
             return;

--- a/wear/src/main/java/eu/inmite/apps/smsjizdenka/activity/MainActivity.java
+++ b/wear/src/main/java/eu/inmite/apps/smsjizdenka/activity/MainActivity.java
@@ -17,6 +17,7 @@
 package eu.inmite.apps.smsjizdenka.activity;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import android.os.Bundle;
 import android.support.wearable.view.WearableListView;
@@ -47,7 +48,7 @@ public class MainActivity extends ProjectBaseActivity {
     @InjectView(R.id.txtError)
     TextView vTxtError;
 
-    private ArrayList<City> mCities;
+    private List<City> mCities;
     private CitiesAdapter mCitiesAdapter;
 
     @Override

--- a/wear/src/main/java/eu/inmite/apps/smsjizdenka/adapter/CitiesAdapter.java
+++ b/wear/src/main/java/eu/inmite/apps/smsjizdenka/adapter/CitiesAdapter.java
@@ -17,6 +17,7 @@
 package eu.inmite.apps.smsjizdenka.adapter;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import android.content.Context;
 import android.support.wearable.view.CircledImageView;
@@ -42,9 +43,9 @@ public class CitiesAdapter extends WearableListView.Adapter {
     private int mDefaultCircleColor;
     private int mSelectedCircleColor;
     private Context mContext;
-    private ArrayList<City> mCities;
+    private List<City> mCities;
 
-    public CitiesAdapter(Context context, ArrayList<City> items) {
+    public CitiesAdapter(Context context, List<City> items) {
         mContext = context;
         this.mCities = items;
         mDefaultCircleColor = context.getResources().getColor(R.color.medium_gray);

--- a/wear/src/main/java/eu/inmite/apps/smsjizdenka/events/CitiesEvent.java
+++ b/wear/src/main/java/eu/inmite/apps/smsjizdenka/events/CitiesEvent.java
@@ -17,6 +17,7 @@
 package eu.inmite.apps.smsjizdenka.events;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import eu.inmite.apps.smsjizdenka.model.City;
 
@@ -25,17 +26,17 @@ import eu.inmite.apps.smsjizdenka.model.City;
  */
 public class CitiesEvent {
 
-    ArrayList<City> mCities;
+    List<City> mCities;
 
-    public CitiesEvent(ArrayList<City> cities) {
+    public CitiesEvent(List<City> cities) {
         mCities = cities;
     }
 
-    public ArrayList<City> getCities() {
+    public List<City> getCities() {
         return mCities;
     }
 
-    public void setCities(ArrayList<City> cities) {
+    public void setCities(List<City> cities) {
         mCities = cities;
     }
 }

--- a/wear/src/main/java/eu/inmite/apps/smsjizdenka/events/TicketsEvent.java
+++ b/wear/src/main/java/eu/inmite/apps/smsjizdenka/events/TicketsEvent.java
@@ -17,6 +17,7 @@
 package eu.inmite.apps.smsjizdenka.events;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import eu.inmite.apps.smsjizdenka.model.City;
 
@@ -25,17 +26,17 @@ import eu.inmite.apps.smsjizdenka.model.City;
  */
 public class TicketsEvent {
 
-    ArrayList<City> mCities;
+    List<City> mCities;
 
-    public TicketsEvent(ArrayList<City> cities) {
+    public TicketsEvent(List<City> cities) {
         mCities = cities;
     }
 
-    public ArrayList<City> getCities() {
+    public List<City> getCities() {
         return mCities;
     }
 
-    public void setCities(ArrayList<City> cities) {
+    public void setCities(List<City> cities) {
         mCities = cities;
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1319 - Declarations should use Java collection interfaces such as List rather than specific implementation classes such as LinkedList.
This pull request removes technical debt of 80 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
George Kankava
