### PR TITLE
squid:S1192 - String literals should not be duplicated

### DIFF
--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/data/CityProvider.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/data/CityProvider.java
@@ -41,6 +41,7 @@ public class CityProvider extends ContentProvider {
     private static final UriMatcher sUriMatcher;
     private static final int CITIES = 1;
     private static final int CITY_ID = 2;
+    public static final String UNKNOWN_URI = "Unknown URI ";
     private static HashMap<String, String> sProjectionMap;
 
     static {
@@ -90,7 +91,7 @@ public class CityProvider extends ContentProvider {
                 break;
 
             default:
-                throw new IllegalArgumentException("Unknown URI " + uri);
+                throw new IllegalArgumentException(UNKNOWN_URI + uri);
         }
 
         getContext().getContentResolver().notifyChange(uri, null);
@@ -106,7 +107,7 @@ public class CityProvider extends ContentProvider {
             case CITY_ID:
                 return Cities.CONTENT_ITEM_TYPE;
             default:
-                throw new IllegalArgumentException("Unknown URI " + uri);
+                throw new IllegalArgumentException(UNKNOWN_URI + uri);
         }
     }
 
@@ -114,7 +115,7 @@ public class CityProvider extends ContentProvider {
     public Uri insert(Uri uri, ContentValues initialValues) {
         // Validate the requested uri
         if (sUriMatcher.match(uri) != CITIES) {
-            throw new IllegalArgumentException("Unknown URI " + uri);
+            throw new IllegalArgumentException(UNKNOWN_URI + uri);
         }
 
         ContentValues values;
@@ -154,7 +155,7 @@ public class CityProvider extends ContentProvider {
                 qb.appendWhere(Cities._ID + "=" + uri.getPathSegments().get(1));
                 break;
             default:
-                throw new IllegalArgumentException("Unknown URI " + uri);
+                throw new IllegalArgumentException(UNKNOWN_URI + uri);
         }
 
         // If no sort order is specified use the default
@@ -190,7 +191,7 @@ public class CityProvider extends ContentProvider {
                 break;
 
             default:
-                throw new IllegalArgumentException("Unknown URI " + uri);
+                throw new IllegalArgumentException(UNKNOWN_URI + uri);
         }
 
         getContext().getContentResolver().notifyChange(uri, null);

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/data/DatabaseHelper.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/data/DatabaseHelper.java
@@ -36,6 +36,12 @@ import eu.inmite.apps.smsjizdenka.framework.DebugLog;
  */
 public class DatabaseHelper extends SQLiteOpenHelper {
 
+    public static final String TEXT = " TEXT;";
+    public static final String ADD = " ADD ";
+    public static final String ALTER_TABLE = "ALTER TABLE ";
+    public static final String INTEGER = " INTEGER;";
+    public static final String TEXT_COMMA = " text,";
+    public static final String INTEGER_COMMA = " integer,";
     public static final String DATABASE_HELPER_SERVICE = "databaseHelperService";
     public static final String TICKET_TABLE_NAME = "ticket";
     public static final String CITY_TABLE_NAME = "city";
@@ -111,7 +117,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
 
         if (oldVersion == 8) {
             try {
-                db.execSQL("ALTER TABLE " + TICKET_TABLE_NAME + " ADD " + TicketProvider.Tickets.SMS_URI + " TEXT;");
+                db.execSQL(ALTER_TABLE + TICKET_TABLE_NAME + ADD + TicketProvider.Tickets.SMS_URI + TEXT);
             } catch (SQLiteException sqle) {
                 // Maybe the table was altered already... Shouldn't be an issue.
             }
@@ -119,8 +125,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         }
         if (oldVersion == 9) {
             try {
-                db.execSQL("ALTER TABLE " + TICKET_TABLE_NAME + " ADD " + TicketProvider.Tickets.CITY_ID + " INTEGER;");
-                db.execSQL("ALTER TABLE " + TICKET_TABLE_NAME + " ADD " + TicketProvider.Tickets.TEXT + " TEXT;");
+                db.execSQL(ALTER_TABLE + TICKET_TABLE_NAME + ADD + TicketProvider.Tickets.CITY_ID + INTEGER);
+                db.execSQL(ALTER_TABLE + TICKET_TABLE_NAME + ADD + TicketProvider.Tickets.TEXT + TEXT);
                 db.execSQL("UPDATE " + TICKET_TABLE_NAME + " SET " + TicketProvider.Tickets.CITY_ID + " = 1");
             } catch (SQLiteException sqle) {
                 // Maybe the table was altered already... Shouldn't be an issue.
@@ -129,10 +135,10 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         }
         if (oldVersion == 10) {
             try {
-                db.execSQL("ALTER TABLE " + TICKET_TABLE_NAME + " ADD " + TicketProvider.Tickets.ORDERED + " TEXT;");
-                db.execSQL("ALTER TABLE " + TICKET_TABLE_NAME + " ADD " + TicketProvider.Tickets.CITY + " TEXT;");
-                db.execSQL("ALTER TABLE " + TICKET_TABLE_NAME + " ADD " + TicketProvider.Tickets.STATUS + " INTEGER;");
-                db.execSQL("ALTER TABLE " + TICKET_TABLE_NAME + " ADD " + TicketProvider.Tickets.NOTIFICATION_ID + " INTEGER;");
+                db.execSQL(ALTER_TABLE + TICKET_TABLE_NAME + ADD + TicketProvider.Tickets.ORDERED + TEXT);
+                db.execSQL(ALTER_TABLE + TICKET_TABLE_NAME + ADD + TicketProvider.Tickets.CITY + TEXT);
+                db.execSQL(ALTER_TABLE + TICKET_TABLE_NAME + ADD + TicketProvider.Tickets.STATUS + INTEGER);
+                db.execSQL(ALTER_TABLE + TICKET_TABLE_NAME + ADD + TicketProvider.Tickets.NOTIFICATION_ID + INTEGER);
 
                 createTableCities(db);
 
@@ -188,23 +194,23 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         sql.append(Tickets._ID);
         sql.append(" integer primary key autoincrement,");
         sql.append(Tickets.ORDERED);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Tickets.VALID_FROM);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Tickets.VALID_TO);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Tickets.VALID_TO_DATE);
-        sql.append(" integer,");
+        sql.append(INTEGER_COMMA);
         sql.append(Tickets.HASH);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Tickets.CITY_ID);
-        sql.append(" integer,");
+        sql.append(INTEGER_COMMA);
         sql.append(Tickets.TEXT);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Tickets.CITY);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Tickets.STATUS);
-        sql.append(" integer,");
+        sql.append(INTEGER_COMMA);
         sql.append(Tickets.NOTIFICATION_ID);
         sql.append(" integer");
         sql.append(");");
@@ -222,47 +228,47 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         sql.append(Cities._ID);
         sql.append(" integer primary key,");
         sql.append(Cities.ADDITIONAL_NUMBER_1);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Cities.ADDITIONAL_NUMBER_2);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Cities.ADDITIONAL_NUMBER_3);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Cities.CITY);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Cities.CITY_PUBTRAN);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Cities.COUNTRY);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Cities.CURRENCY);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Cities.IDENTIFICATION);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Cities.LAT);
         sql.append(" double,");
         sql.append(Cities.LON);
         sql.append(" double,");
         sql.append(Cities.NOTE);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Cities.NUMBER);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Cities.P_DATE_FROM);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Cities.P_DATE_TO);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Cities.P_HASH);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Cities.PRICE);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Cities.PRICE_NOTE);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Cities.REQUEST);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Cities.VALIDITY);
-        sql.append(" integer,");
+        sql.append(INTEGER_COMMA);
         sql.append(Cities.DATE_FORMAT);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Cities.CONFIRM_REQ);
-        sql.append(" text,");
+        sql.append(TEXT_COMMA);
         sql.append(Cities.CONFIRM);
         sql.append(" text");
         sql.append(");");

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/data/TicketProvider.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/data/TicketProvider.java
@@ -38,6 +38,7 @@ import eu.inmite.apps.smsjizdenka.BuildConfig;
 public class TicketProvider extends ContentProvider {
 
     public static final String AUTHORITY = BuildConfig.APPLICATION_ID + ".ticket";
+    public static final String UNKNOWN_URI = "Unknown URI ";
     private static final UriMatcher sUriMatcher;
     private static final int TICKETS = 1;
     private static final int TICKET_ID = 2;
@@ -78,7 +79,7 @@ public class TicketProvider extends ContentProvider {
                 break;
 
             default:
-                throw new IllegalArgumentException("Unknown URI " + uri);
+                throw new IllegalArgumentException(UNKNOWN_URI + uri);
         }
 
         getContext().getContentResolver().notifyChange(uri, null);
@@ -94,7 +95,7 @@ public class TicketProvider extends ContentProvider {
             case TICKET_ID:
                 return Tickets.CONTENT_ITEM_TYPE;
             default:
-                throw new IllegalArgumentException("Unknown URI " + uri);
+                throw new IllegalArgumentException(UNKNOWN_URI + uri);
         }
     }
 
@@ -102,7 +103,7 @@ public class TicketProvider extends ContentProvider {
     public Uri insert(Uri uri, ContentValues initialValues) {
         // Validate the requested uri
         if (sUriMatcher.match(uri) != TICKETS) {
-            throw new IllegalArgumentException("Unknown URI " + uri);
+            throw new IllegalArgumentException(UNKNOWN_URI + uri);
         }
 
         ContentValues values;
@@ -143,7 +144,7 @@ public class TicketProvider extends ContentProvider {
                 qb.appendWhere(Tickets._ID + "=" + uri.getPathSegments().get(1));
                 break;
             default:
-                throw new IllegalArgumentException("Unknown URI " + uri);
+                throw new IllegalArgumentException(UNKNOWN_URI + uri);
         }
 
         // If no sort order is specified use the default
@@ -179,7 +180,7 @@ public class TicketProvider extends ContentProvider {
                 break;
 
             default:
-                throw new IllegalArgumentException("Unknown URI " + uri);
+                throw new IllegalArgumentException(UNKNOWN_URI + uri);
         }
 
         getContext().getContentResolver().notifyChange(uri, null);

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/data/model/City.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/data/model/City.java
@@ -38,12 +38,13 @@ import eu.inmite.apps.smsjizdenka.util.CannotParseException;
  */
 public class City {
 
+    public static final String EUROPE_PRAGUE = "Europe/Prague";
     private static final SimpleDateFormat format3339 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
     private static final SimpleDateFormat timezone = new SimpleDateFormat("Z");
 
     static {
-        format3339.setCalendar(Calendar.getInstance(TimeZone.getTimeZone("Europe/Prague"), new Locale("cs", "CZ")));
-        timezone.setCalendar(Calendar.getInstance(TimeZone.getTimeZone("Europe/Prague"), new Locale("cs", "CZ")));
+        format3339.setCalendar(Calendar.getInstance(TimeZone.getTimeZone(EUROPE_PRAGUE), new Locale("cs", "CZ")));
+        timezone.setCalendar(Calendar.getInstance(TimeZone.getTimeZone(EUROPE_PRAGUE), new Locale("cs", "CZ")));
     }
 
     public long id;
@@ -114,12 +115,12 @@ public class City {
         this.confirm = confirm;
 
         this.sdf = new SimpleDateFormat(dateFormat);
-        sdf.setCalendar(Calendar.getInstance(TimeZone.getTimeZone("Europe/Prague"), new Locale("cs", "CZ")));
+        sdf.setCalendar(Calendar.getInstance(TimeZone.getTimeZone(EUROPE_PRAGUE), new Locale("cs", "CZ")));
 
         String[] dateFormatParts = dateFormat.split(" ");
         if (dateFormatParts.length > 1) {
             this.sdfTime = new SimpleDateFormat(dateFormatParts[1]);
-            sdfTime.setCalendar(Calendar.getInstance(TimeZone.getTimeZone("Europe/Prague"), new Locale("cs", "CZ")));
+            sdfTime.setCalendar(Calendar.getInstance(TimeZone.getTimeZone(EUROPE_PRAGUE), new Locale("cs", "CZ")));
         }
     }
 

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/dialog/MessageDialogFragment.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/dialog/MessageDialogFragment.java
@@ -29,12 +29,13 @@ import eu.inmite.apps.smsjizdenka.R;
  */
 public class MessageDialogFragment extends BaseDialogFragment {
 
-    public static String TAG = "message";
+    public static final String MESSAGE = "message";
+    public static String TAG = MESSAGE;
 
     public static MessageDialogFragment newInstance(String message) {
         MessageDialogFragment dialog = new MessageDialogFragment();
         Bundle args = new Bundle();
-        args.putString("message", message);
+        args.putString(MESSAGE, message);
         dialog.setArguments(args);
         return dialog;
     }
@@ -52,6 +53,6 @@ public class MessageDialogFragment extends BaseDialogFragment {
     }
 
     private String getMessage() {
-        return getArguments().getString("message");
+        return getArguments().getString(MESSAGE);
     }
 }

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/fragment/SettingsFragment.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/fragment/SettingsFragment.java
@@ -54,6 +54,7 @@ import eu.inmite.apps.smsjizdenka.service.UpdateService;
  */
 public class SettingsFragment extends PreferenceListFragment {
 
+    public static final String SMS_CATEGORY = "sms_category";
     private Context mContext;
     SharedPreferences.OnSharedPreferenceChangeListener listener = new SharedPreferences
         .OnSharedPreferenceChangeListener() {
@@ -114,12 +115,12 @@ public class SettingsFragment extends PreferenceListFragment {
         updateDataVersion(preferenceScreen);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            PreferenceCategory pref = (PreferenceCategory) preferenceScreen.findPreference("sms_category");
+            PreferenceCategory pref = (PreferenceCategory) preferenceScreen.findPreference(SMS_CATEGORY);
             pref.removePreference(pref.findPreference(Preferences.KEEP_IN_MESSAGING));
         }
         boolean dualSim = Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1 && SubscriptionManager.from(getActivity()).getActiveSubscriptionInfoCount() >= 2;
         if (!dualSim) {
-            PreferenceCategory pref = (PreferenceCategory) preferenceScreen.findPreference("sms_category");
+            PreferenceCategory pref = (PreferenceCategory) preferenceScreen.findPreference(SMS_CATEGORY);
             pref.removePreference(pref.findPreference(Preferences.DUALSIM_SIM));
         } else {
             fillDualSimList(preferenceScreen);
@@ -128,7 +129,7 @@ public class SettingsFragment extends PreferenceListFragment {
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP_MR1)
     private void fillDualSimList(PreferenceScreen preferenceScreen) {
-        PreferenceCategory category = (PreferenceCategory) preferenceScreen.findPreference("sms_category");
+        PreferenceCategory category = (PreferenceCategory) preferenceScreen.findPreference(SMS_CATEGORY);
         ListPreference preference = (ListPreference) category.findPreference(Preferences.DUALSIM_SIM);
         List<String> simIds = new ArrayList<>();
         List<String> simNames = new ArrayList<>();

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/framework/about/Constants.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/framework/about/Constants.java
@@ -30,36 +30,39 @@ public class Constants {
     public static final License ISC = new License("ORM Lite License", "http://ormlite.com/javadoc/ormlite-core/doc-files/ormlite_9.html#License");
     public static final License BSD3 = new License("BSD 3-Clause License", "http://opensource.org/licenses/BSD-3-Clause");
 
+    public static final String JAKE_WHARTON = "Jake Wharton";
+    public static final String SQUARE = "Square";
+    public static final String GOOGLE = "Google";
     /**
      * Add more libraries if you use more than it's in this list.
      */
     public static final Library[] KNOWN_LIBRARIES = {
-        new Library("com.actionbarsherlock.app.ActionBar", "ActionBarSherlock", "Jake Wharton", APACHE, "https://github.com/JakeWharton/ActionBarSherlock"),
-        new Library("com.viewpagerindicator.PagerIndicator", "ViewPagerIndicator", "Jake Wharton", APACHE, "https://github.com/JakeWharton/Android-ViewPagerIndicator"),
-        new Library("com.nineoldandroids.view.ViewHelper", "NineOldAndroids", "Jake Wharton", APACHE, "https://github.com/JakeWharton/NineOldAndroids"),
-        new Library("com.jakewharton.disklrucache.DiskLruCache", "DiskLruCache", "Jake Wharton", APACHE, "https://github.com/JakeWharton/DiskLruCache"),
+        new Library("com.actionbarsherlock.app.ActionBar", "ActionBarSherlock", JAKE_WHARTON, APACHE, "https://github.com/JakeWharton/ActionBarSherlock"),
+        new Library("com.viewpagerindicator.PagerIndicator", "ViewPagerIndicator", JAKE_WHARTON, APACHE, "https://github.com/JakeWharton/Android-ViewPagerIndicator"),
+        new Library("com.nineoldandroids.view.ViewHelper", "NineOldAndroids", JAKE_WHARTON, APACHE, "https://github.com/JakeWharton/NineOldAndroids"),
+        new Library("com.jakewharton.disklrucache.DiskLruCache", "DiskLruCache", JAKE_WHARTON, APACHE, "https://github.com/JakeWharton/DiskLruCache"),
         new Library("com.nostra13.universalimageloader.core.ImageLoader", "Universal Image Loader", "Sergey Tarasevich", APACHE, "https://github.com/nostra13/Android-Universal-Image-Loader"),
         new Library("com.github.kevinsawicki.http.HttpRequest", "Http Request", "Kewin Sawacki", MIT, "https://github.com/kevinsawicki/http-request"),
         new Library("com.fasterxml.jackson.core.JsonParser", "Jackson", "FasterXML, LLC", APACHE, "https://github.com/FasterXML/jackson"),
         new Library("com.integralblue.httpresponsecache.HttpResponseCache", "HttpResponseCache", "Craig", APACHE, "https://github.com/candrews/HttpResponseCache"),
         new Library("com.google.zxing.Reader", "zxing", "zxing team", APACHE, "https://code.google.com/p/zxing/"),
-        new Library("butterknife.ButterKnife", "Butter Knife", "Square", APACHE, "https://github.com/JakeWharton/butterknife"),
-        new Library("com.squareup.picasso.Picasso", "Picasso", "Square", APACHE, "https://github.com/square/picasso"),
-        new Library("com.squareup.okhttp.OkHttpClient", "OK HTTP", "Square", APACHE, "https://github.com/square/okhttp"),
-        new Library("retrofit.RestAdapter", "Retrofit", "Square", APACHE, "https://github.com/square/retrofit"),
-        new Library("com.squareup.otto.Bus", "Otto", "Square", APACHE, "https://github.com/square/otto"),
-        new Library("android.support.v4.app.Fragment", "Android Support Library", "Google", APACHE, "http://developer.android.com/tools/support-library/index.html"),
-        new Library("android.support.v7.app.ActionBar", "Android Appcompat Library", "Google", APACHE, "https://developer.android.com/tools/support-library/features.html#v7-appcompat"),
-        new Library("com.google.gson.Gson", "GSON", "Google", APACHE, "https://code.google.com/p/google-gson/"),
-        new Library("com.google.android.gms.common.GooglePlayServicesUtil", "Play Services", "Google", APACHE_PLAY_SERVICES, "http://developer.android.com/google/play-services/index.html"),
-        new Library("com.android.volley.Request", "Volley", "Google", APACHE, "https://android.googlesource.com/platform/frameworks/volley"),
+        new Library("butterknife.ButterKnife", "Butter Knife", SQUARE, APACHE, "https://github.com/JakeWharton/butterknife"),
+        new Library("com.squareup.picasso.Picasso", "Picasso", SQUARE, APACHE, "https://github.com/square/picasso"),
+        new Library("com.squareup.okhttp.OkHttpClient", "OK HTTP", SQUARE, APACHE, "https://github.com/square/okhttp"),
+        new Library("retrofit.RestAdapter", "Retrofit", SQUARE, APACHE, "https://github.com/square/retrofit"),
+        new Library("com.squareup.otto.Bus", "Otto", SQUARE, APACHE, "https://github.com/square/otto"),
+        new Library("android.support.v4.app.Fragment", "Android Support Library", GOOGLE, APACHE, "http://developer.android.com/tools/support-library/index.html"),
+        new Library("android.support.v7.app.ActionBar", "Android Appcompat Library", GOOGLE, APACHE, "https://developer.android.com/tools/support-library/features.html#v7-appcompat"),
+        new Library("com.google.gson.Gson", "GSON", GOOGLE, APACHE, "https://code.google.com/p/google-gson/"),
+        new Library("com.google.android.gms.common.GooglePlayServicesUtil", "Play Services", GOOGLE, APACHE_PLAY_SERVICES, "http://developer.android.com/google/play-services/index.html"),
+        new Library("com.android.volley.Request", "Volley", GOOGLE, APACHE, "https://android.googlesource.com/platform/frameworks/volley"),
         new Library("com.avast.android.dialogs.core.BaseDialogFragment", "StyledDialogs for Android", "Avast Sofware", APACHE, "https://github.com/inmite/android-styled-dialogs"),
         new Library("pl.mg6.android.maps.extensions.SupportMapFragment", "Android Maps Extensions", "Maciej Górski", APACHE, "https://code.google.com/p/android-maps-extensions/"),
         new Library("com.caldroid.CaldroidFragment", "CalDroid", "Roomorama", MIT, "https://github.com/roomorama/Caldroid"),
         new Library("org.simpleframework.xml.core.Persister", "Simple", "Niall Gallagher", APACHE, "http://simple.sourceforge.net/home.php"),
         new Library("com.j256.ormlite.dao.Dao", "ORM Lite", "Gray Watson", ISC, "http://ormlite.com/"),
         new Library("com.pnikosis.materialishprogress.ProgressWheel", "Material-ish Progress", "Nicolás Hormazál", APACHE, "htps://github.com/pnikosis/materialish-progress"),
-        new Library("com.google.protobuf.Parser", "Protocol Buffers", "Google", BSD3, "https://code.google.com/p/protobuf"),
+        new Library("com.google.protobuf.Parser", "Protocol Buffers", GOOGLE, BSD3, "https://code.google.com/p/protobuf"),
         new Library("com.tonicartos.widget.stickygridheaders.StickyGridHeadersGridView", "StickyGridHeaders", "Tonic Artos", APACHE, "https://github.com/TonicArtos/StickyGridHeaders"),
         new Library("com.tonicartos.superslim.GridSLM", "SuperSLiM", "Tonic Artos", APACHE, "https://github.com/TonicArtos/SuperSLiM"),
         new Library("com.hudomju.swipe.OnItemClickListener", "Swipe to dismiss", "Hugo Doménech Juárez", MIT, "https://github.com/hudomju/android-swipe-to-dismiss-undo"),

--- a/mobile/src/main/java/eu/inmite/apps/smsjizdenka/framework/util/StreamUtils.java
+++ b/mobile/src/main/java/eu/inmite/apps/smsjizdenka/framework/util/StreamUtils.java
@@ -33,19 +33,21 @@ import eu.inmite.apps.smsjizdenka.framework.DebugLog;
  */
 public class StreamUtils {
 
+    public static final String STREAM_UTILS_STREAM_TO_STRING_FAILED = "StreamUtils.streamToString() failed";
+
     private StreamUtils() {}
 
     public static String streamToString(InputStream is) throws IOException {
         try {
             return streamToString(new InputStreamReader(is, "UTF-8"));
         } catch (UnsupportedEncodingException e) {
-            DebugLog.e("StreamUtils.streamToString() failed", e);
+            DebugLog.e(STREAM_UTILS_STREAM_TO_STRING_FAILED, e);
             return "";
         } finally {
             try {
                 is.close();
             } catch (IOException e) {
-                DebugLog.e("StreamUtils.streamToString() failed", e);
+                DebugLog.e(STREAM_UTILS_STREAM_TO_STRING_FAILED, e);
             }
         }
     }
@@ -62,12 +64,12 @@ public class StreamUtils {
                     writer.write(buffer, 0, n);
                 }
             } catch (UnsupportedEncodingException e) {
-                DebugLog.e("StreamUtils.streamToString() failed", e);
+                DebugLog.e(STREAM_UTILS_STREAM_TO_STRING_FAILED, e);
             } finally {
                 try {
                     isr.close();
                 } catch (IOException e) {
-                    DebugLog.e("StreamUtils.streamToString() failed", e);
+                    DebugLog.e(STREAM_UTILS_STREAM_TO_STRING_FAILED, e);
                 }
             }
             return writer.toString();

--- a/mobile/src/test/java/eu/inmite/apps/smsjizdenka/SmsParserCzechTest.java
+++ b/mobile/src/test/java/eu/inmite/apps/smsjizdenka/SmsParserCzechTest.java
@@ -16,6 +16,7 @@
 
 package eu.inmite.apps.smsjizdenka;
 
+import java.lang.String;
 import java.util.Date;
 
 import org.junit.Assert;
@@ -34,6 +35,8 @@ import eu.inmite.apps.smsjizdenka.util.Ticket;
  */
 public class SmsParserCzechTest {
 
+    public static final String PRAHA = "Praha";
+    public static final String NEEDS_NEW_SMS_DEFINITION = "Needs new SMS definition";
     static SmsParser sSmsParser;
 
     @BeforeClass
@@ -48,7 +51,7 @@ public class SmsParserCzechTest {
     @Test
     public void testDpt24() {
         Ticket ticket = sSmsParser.parse("90206024", "DP hl.m.Prahy, a.s., Jizdenka prestupni 24,- Kc, Platnost od: 11.7.11 19:29  do: 11.7.11 19:59. Pouze v pasmu P. bhAJpWP9B / 861418");
-        Assert.assertEquals("Praha", ticket.city);
+        Assert.assertEquals(PRAHA, ticket.city);
         Assert.assertEquals(24, ticket.price, 0);
         Assert.assertEquals("bhAJpWP9B / 861418", ticket.hash);
         Assert.assertEquals(new Date("July 11, 2011, 19:29:00"), ticket.validFrom);
@@ -58,7 +61,7 @@ public class SmsParserCzechTest {
     @Test
     public void testDpt32() {
         Ticket ticket = sSmsParser.parse("90206032", "DP hl.m.Prahy, a.s., Jizdenka prestupni 32,- Kc, Platnost od: 29.8.11 8:09  do: 29.8.11 9:39. Pouze v pasmu P. WzL9n3JuQ / 169605");
-        Assert.assertEquals("Praha", ticket.city);
+        Assert.assertEquals(PRAHA, ticket.city);
         Assert.assertEquals(32, ticket.price, 0);
         Assert.assertEquals("WzL9n3JuQ / 169605", ticket.hash);
         Assert.assertEquals(new Date("August 29, 2011, 8:09:00"), ticket.validFrom);
@@ -68,7 +71,7 @@ public class SmsParserCzechTest {
     @Test
     public void testDpt110() {
         Ticket ticket = sSmsParser.parse("90206110", "DP hl.m.Prahy, a.s., Jizdenka prestupni 110,- Kc, Platnost od: 3.7.11 19:50  do: 4.7.11 19:50. Pouze v pasmu P. yjCNXTCEc / 5892179");
-        Assert.assertEquals("Praha", ticket.city);
+        Assert.assertEquals(PRAHA, ticket.city);
         Assert.assertEquals(110, ticket.price, 0);
         Assert.assertEquals("yjCNXTCEc / 5892179", ticket.hash);
         Assert.assertEquals(new Date("July 3, 2011, 19:50:00"), ticket.validFrom);
@@ -145,7 +148,7 @@ public class SmsParserCzechTest {
         Assert.assertEquals("KMyzC9U7s / 160852", ticket.hash);
         Assert.assertEquals(new Date("January 1, 2012, 10:54:00"), ticket.validFrom);
         Assert.assertEquals(new Date("January 1, 2012, 11:54:00"), ticket.validTo);*/
-        new UnsupportedOperationException("Needs new SMS definition");
+        new UnsupportedOperationException(NEEDS_NEW_SMS_DEFINITION);
     }
 
     // ------ Liberec - Jablonec nad Nisou
@@ -190,7 +193,7 @@ public class SmsParserCzechTest {
         Assert.assertEquals("qii3LqjjE/228335/fWR", ticket.hash);
         Assert.assertEquals(new Date("February 5, 2012, 9:16:00"), ticket.validFrom);
         Assert.assertEquals(new Date("February 5, 2012, 10:01:00"), ticket.validTo);*/
-        new UnsupportedOperationException("Needs new SMS definition");
+        new UnsupportedOperationException(NEEDS_NEW_SMS_DEFINITION);
     }
 
     @Test
@@ -201,7 +204,7 @@ public class SmsParserCzechTest {
         Assert.assertEquals("ArxFyuqHP/669942/MWf", ticket.hash);
         Assert.assertEquals(new Date("February 5, 2012, 9:15:00"), ticket.validFrom);
         Assert.assertEquals(new Date("February 6, 2012, 9:15:00"), ticket.validTo);*/
-        new UnsupportedOperationException("Needs new SMS definition");
+        new UnsupportedOperationException(NEEDS_NEW_SMS_DEFINITION);
     }
 
     // ------ Hradec Kralove

--- a/mobile/src/test/java/eu/inmite/apps/smsjizdenka/SmsParserSlovakTest.java
+++ b/mobile/src/test/java/eu/inmite/apps/smsjizdenka/SmsParserSlovakTest.java
@@ -16,6 +16,7 @@
 
 package eu.inmite.apps.smsjizdenka;
 
+import java.lang.String;
 import java.util.Date;
 
 import org.junit.Assert;
@@ -27,6 +28,7 @@ import eu.inmite.apps.smsjizdenka.util.Ticket;
 
 public class SmsParserSlovakTest {
 
+    public static final String BRATISLAVA = "Bratislava";
     static SmsParser sSmsParser;
 
     @BeforeClass
@@ -40,7 +42,7 @@ public class SmsParserSlovakTest {
     @Test
     public void test1100() {
         Ticket ticket = sSmsParser.parse("1100", "DPB, a.s. Prestupny CL 1,30EUR Platnost od 24-08-2011 18:42 do 19:52 hod. gwyywg4u6bh");
-        Assert.assertEquals("Bratislava", ticket.city);
+        Assert.assertEquals(BRATISLAVA, ticket.city);
         Assert.assertEquals(1.30, ticket.price, 0);
         Assert.assertEquals("gwyywg4u6bh", ticket.hash);
         Assert.assertEquals(new Date("August 24, 2011, 18:42:00"), ticket.validFrom);
@@ -50,7 +52,7 @@ public class SmsParserSlovakTest {
     @Test
     public void test1104() {
         Ticket ticket = sSmsParser.parse("1140", "DPB, a.s. Prestupny CL 1,00EUR Platnost od 24-08-2011 18:42 do 19:52 hod. gwyywg4u6bh");
-        Assert.assertEquals("Bratislava", ticket.city);
+        Assert.assertEquals(BRATISLAVA, ticket.city);
         Assert.assertEquals(1, ticket.price, 0);
         Assert.assertEquals("gwyywg4u6bh", ticket.hash);
         Assert.assertEquals(new Date("August 24, 2011, 18:42:00"), ticket.validFrom);
@@ -60,7 +62,7 @@ public class SmsParserSlovakTest {
     @Test
     public void test1124() {
         Ticket ticket = sSmsParser.parse("1124", "DPB, a.s. Prestupny 24 hod CL 3,50EUR Platnost od 26-11-2009 18:55 do 27-11-2009 18:55 hod. nhn1knmtytx");
-        Assert.assertEquals("Bratislava", ticket.city);
+        Assert.assertEquals(BRATISLAVA, ticket.city);
         Assert.assertEquals(4.50, ticket.price, 0.0);
         Assert.assertEquals("nhn1knmtytx", ticket.hash);
         Assert.assertEquals(new Date("November 26, 2009, 18:55:00"), ticket.validFrom);

--- a/mobile/src/test/java/eu/inmite/apps/smsjizdenka/util/SmsParser.java
+++ b/mobile/src/test/java/eu/inmite/apps/smsjizdenka/util/SmsParser.java
@@ -20,6 +20,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.String;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -38,6 +39,7 @@ import org.json.JSONObject;
  */
 public class SmsParser {
 
+    public static final String JSON_PARSING_ERROR = "JSON Parsing Error";
     private List<City> mCities;
 
     public SmsParser(String lang) {
@@ -92,14 +94,14 @@ public class SmsParser {
                 mCities.add(city);
             }
         } catch (IOException | JSONException e) {
-            throw new RuntimeException("JSON Parsing Error");
+            throw new RuntimeException(JSON_PARSING_ERROR);
         } finally {
             try {
                 if (is != null) {
                     is.close();
                 }
             } catch (IOException e) {
-                throw new RuntimeException("JSON Parsing Error");
+                throw new RuntimeException(JSON_PARSING_ERROR);
             }
         }
     }
@@ -212,7 +214,7 @@ public class SmsParser {
                 value = json.getString(key);
             }
         } catch (JSONException je) {
-            throw new RuntimeException("JSON Parsing Error");
+            throw new RuntimeException(JSON_PARSING_ERROR);
         }
 
         return value;

--- a/wear/src/main/java/eu/inmite/apps/smsjizdenka/service/ListenerService.java
+++ b/wear/src/main/java/eu/inmite/apps/smsjizdenka/service/ListenerService.java
@@ -49,6 +49,8 @@ import eu.inmite.apps.smsjizdenka.util.ImageUtil;
  */
 public class ListenerService extends TeleportService {
 
+    public static final String TICKET = "ticket";
+
     @Override
     public void onCreate() {
         super.onCreate();
@@ -65,7 +67,7 @@ public class ListenerService extends TeleportService {
 
         if (intent != null && intent.getAction() != null) {
             if ("open_ticket".equals(intent.getAction())) {
-                final Ticket t = (Ticket)intent.getExtras().getSerializable("ticket");
+                final Ticket t = (Ticket)intent.getExtras().getSerializable(TICKET);
                 sendMessage("openTicket/" + t.getId(), null);
 
                 Intent confirmationIntent = new Intent(this, ConfirmationActivity.class);
@@ -138,7 +140,7 @@ public class ListenerService extends TeleportService {
         ticket.setNotificationId(dataMap1.getLong("notification_id"));
 
         Intent notificationIntent = new Intent(this, NotificationActivity.class);
-        notificationIntent.putExtra("ticket", ticket);
+        notificationIntent.putExtra(TICKET, ticket);
         PendingIntent notificationPendingIntent = PendingIntent.getActivity(this, 0, notificationIntent,
             PendingIntent.FLAG_UPDATE_CURRENT);
 
@@ -164,7 +166,7 @@ public class ListenerService extends TeleportService {
 
         Intent intent = new Intent(this, OpenPhoneReceiver.class);
         intent.setAction("eu.inmite.apps.smsjizdenka.openphone");
-        intent.putExtra("ticket", ticket);
+        intent.putExtra(TICKET, ticket);
         PendingIntent openPhonePendingIntent = PendingIntent.getBroadcast(this, 0, intent,
             PendingIntent.FLAG_UPDATE_CURRENT);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1192 - String literals should not be duplicated.
This pull request removes 248 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
George Kankava
